### PR TITLE
Add wordcount tutorial to docs nix packaging

### DIFF
--- a/funflow-tutorial/package.yaml
+++ b/funflow-tutorial/package.yaml
@@ -41,3 +41,6 @@ executables:
       - regex-posix 
       - text
       - containers
+    build-tools:
+      - inliterate:inlitpp
+  

--- a/nix/docs/docs-tutorial.nix
+++ b/nix/docs/docs-tutorial.nix
@@ -3,13 +3,18 @@ let
 
   project = import ./../default.nix;
 in pkgs.runCommand "funflow-tutorial-generated" {
+  src = ../../funflow-tutorial;
   buildInputs = [
     project.funflow-tutorial.components.exes.quick-reference
     project.funflow-tutorial.components.exes.tutorial1
+    project.funflow-tutorial.components.exes.wordcount
   ];
+  # wordcount reads a "words.txt" file from the working directory
+  # Here, we take the example included with funflow-tutorial
 } ''
   mkdir -p $out/docs/tutorial
-  cd $out/docs/tutorial
-  quick-reference > quick-reference.html
-  tutorial1 > tutorial1.html
+  cp $src/words.txt .
+  quick-reference > $out/docs/tutorial/quick-reference.html
+  tutorial1 > $out/docs/tutorial/tutorial1.html
+  wordcount > $out/docs/tutorial/wordcount.html
 ''


### PR DESCRIPTION
Added the wordcount tutorial's html output to `nix/docs`
