### PR TITLE
Add method for streaming container logs

### DIFF
--- a/docker-client/src/Docker/API/Client.hs
+++ b/docker-client/src/Docker/API/Client.hs
@@ -15,6 +15,7 @@ module Docker.API.Client
     ContainerLogType (..),
     pullImage,
     awaitContainer,
+    printContainerLogs,
   )
 where
 
@@ -26,6 +27,7 @@ import Docker.API.Client.Internal.Connection
 import Docker.API.Client.Internal.Requests
   ( awaitContainer,
     dockerAPIVersion,
+    printContainerLogs,
     pullImage,
     removeContainer,
     runContainer,

--- a/funflow/src/Funflow/Run.hs
+++ b/funflow/src/Funflow/Run.hs
@@ -48,12 +48,14 @@ import Data.Set (fromList)
 import Data.String (IsString (fromString))
 import qualified Data.Text as T
 import Docker.API.Client
-  ( ContainerSpec (cmd),
+  ( ContainerLogType (..),
+    ContainerSpec (cmd),
     OS (OS),
     awaitContainer,
     defaultContainerSpec,
     hostVolumes,
     newDefaultDockerManager,
+    printContainerLogs,
     pullImage,
     runContainer,
     saveContainerArchive,
@@ -280,6 +282,7 @@ interpretDockerTask manager store (DockerTask (DockerTaskConfig {DE.image, DE.co
                             -- Run the docker container
                             runDockerResult <- runExceptT $ do
                               containerId <- runContainer manager container
+                              printContainerLogs manager Both containerId
                               awaitContainer manager containerId
                               return containerId
                             -- Process the result of the docker computation


### PR DESCRIPTION
This PR adds an additional method for streaming container logs to stdout in `docker-client` and adds a call to it in the DockerTask interpreter. This is a temporary solution until we define a structure for handling logging, etc. in funflow2.
