### PR TITLE
Update DockerTask output hashing

### DIFF
--- a/funflow/package.yaml
+++ b/funflow/package.yaml
@@ -29,6 +29,7 @@ dependencies:
   - path-io
   - safe-exceptions
   - store
+  - temporary
   - text
   - unix-compat
   - unliftio

--- a/funflow/src/System/Directory/Funflow.hs
+++ b/funflow/src/System/Directory/Funflow.hs
@@ -14,7 +14,6 @@ import System.Directory (copyFile, doesDirectoryExist, doesFileExist, listDirect
 moveDirectoryContent :: Path Abs Dir -> Path Abs Dir -> IO ()
 moveDirectoryContent sourceDirectory targetDirectory =
   do
-    putStrLn $ "Attempting to move " <> (show sourceDirectory) <> " to: " <> (show targetDirectory)
     -- List of directories inside
     dirPaths <-
       -- Get the list of children elements of @directory@

--- a/funflow/src/System/Directory/Funflow.hs
+++ b/funflow/src/System/Directory/Funflow.hs
@@ -2,15 +2,19 @@
 
 module System.Directory.Funflow (moveDirectoryContent) where
 
+import Control.Exception (catch, throw)
 import Control.Monad (filterM)
 import Data.Maybe (catMaybes)
+import Foreign.C.Error (Errno (Errno), eXDEV)
+import GHC.IO.Exception (IOException (ioe_errno))
 import Path (Abs, Dir, Path, dirname, filename, parseRelDir, parseRelFile, toFilePath, (</>))
-import System.Directory (doesDirectoryExist, doesFileExist, listDirectory, renamePath)
+import System.Directory (copyFile, doesDirectoryExist, doesFileExist, listDirectory, removeFile, renamePath)
 
 -- | Move all the directories and files from a source directory to a target directory
 moveDirectoryContent :: Path Abs Dir -> Path Abs Dir -> IO ()
 moveDirectoryContent sourceDirectory targetDirectory =
   do
+    putStrLn $ "Attempting to move " <> (show sourceDirectory) <> " to: " <> (show targetDirectory)
     -- List of directories inside
     dirPaths <-
       -- Get the list of children elements of @directory@
@@ -44,8 +48,17 @@ moveDirectoryContent sourceDirectory targetDirectory =
         filterM (doesFileExist . toFilePath)
 
     -- Move directories and files
-    mapM_ (uncurry renamePath) [(toFilePath dirPath, toFilePath $ targetDirectory </> dirname dirPath) | dirPath <- dirPaths]
-    mapM_ (uncurry renamePath) [(toFilePath filePath, toFilePath $ targetDirectory </> filename filePath) | filePath <- filePaths]
+    mapM_ (uncurry moveOrCopy) [(toFilePath dirPath, toFilePath $ targetDirectory </> dirname dirPath) | dirPath <- dirPaths]
+    mapM_ (uncurry moveOrCopy) [(toFilePath filePath, toFilePath $ targetDirectory </> filename filePath) | filePath <- filePaths]
 
     -- Finish
     return ()
+  where
+    -- Need to handle cases where the source directory is on a different disk than the destination directory since
+    -- rename will fail in these cases.
+    moveOrCopy srcFilePath destFilePath = renamePath srcFilePath destFilePath `catch` exdev srcFilePath destFilePath
+    -- Stolen from: https://github.com/mihaimaruseac/hindent/issues/170
+    exdev srcFilePath destFilePath e =
+      if ioe_errno e == Just ((\(Errno a) -> a) eXDEV)
+        then copyFile srcFilePath destFilePath >> removeFile srcFilePath
+        else throw e


### PR DESCRIPTION
Updated how DockerTask file outputs are copied to the CAS so that the hashing method is called on the file content instead of some arbitrary inputs (#67). This now writes files to a temporary directory, computes the hash on that, then copies it to the CAS. To support this 2-step operation, I also had to update `moveDirectoryContent` to copy files in cases where the temp directory resides on a separate disk from the CAS (e.g. this can happen when running in a nix-shell).