### PR TITLE
Add C compilation tutorial

### DIFF
--- a/funflow-pages/src/tutorials/index.html
+++ b/funflow-pages/src/tutorials/index.html
@@ -48,7 +48,17 @@
             </div>
             <div class="toc-tutorial-item">
                 <div class="toc-tutorial-item-title">
-                    <a href="/funflow2/tutorials/ErrorHandling.html">3. Error handling</a>
+                    <a href="/funflow2/tutorials/CCompilation.html">4. Compiling C programs</a>
+                </div>
+                <div class="toc-tutorial-item-description">
+                    <p>
+                        Compile and execute a simple C program using funflow.
+                    </p>
+                </div>
+            </div>
+            <div class="toc-tutorial-item">
+                <div class="toc-tutorial-item-title">
+                    <a href="/funflow2/tutorials/ErrorHandling.html">5. Error handling</a>
                 </div>
                 <div class="toc-tutorial-item-description">
                     <p>
@@ -58,7 +68,7 @@
             </div>
             <div class="toc-tutorial-item">
                 <div class="toc-tutorial-item-title">
-                    <a href="/funflow2/tutorials/ExternalConfig.html">4. Configuration</a>
+                    <a href="/funflow2/tutorials/ExternalConfig.html">6. Configuration</a>
                 </div>
                 <div class="toc-tutorial-item-description">
                     <p>
@@ -68,7 +78,7 @@
             </div>
             <div class="toc-tutorial-item">
                 <div class="toc-tutorial-item-title">
-                    <a href="/funflow2/tutorials/Tutorial2.html">5. Advanced Tutorial</a>
+                    <a href="/funflow2/tutorials/Tutorial2.html">7. Advanced Tutorial</a>
                 </div>
                 <div class="toc-tutorial-item-description">
                     <p>
@@ -79,7 +89,7 @@
             <div class="toc-tutorial-item">
                 <div class="toc-tutorial-item-title">
                     <a href="/funflow2/tutorials/TensorflowDocker.html">
-                        6. Hands-on: ML Pipeline with Docker and TensorFlow
+                        8. Hands-on: ML Pipeline with Docker and TensorFlow
                     </a>
                 </div>
                 <div class="toc-tutorial-item-description">

--- a/funflow-tutorial/notebooks/CCompilation/CCompilation.ipynb
+++ b/funflow-tutorial/notebooks/CCompilation/CCompilation.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compiling and running C programs\n",
+    "\n",
+    "As in [the example](https://github.com/tweag/funflow/tree/v1.5.0/funflow-examples/compile-and-run-c-files) in funflow version 1, we can construct a `Flow` which compiles and executes a C program. As in the older versions of this example, we will use the `gcc` Docker image to run our compilation step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ":opt no-lint\n",
+    "\n",
+    "{-# LANGUAGE Arrows #-}\n",
+    "{-# LANGUAGE OverloadedStrings #-}\n",
+    "{-# LANGUAGE QuasiQuotes #-}\n",
+    "\n",
+    "-- Funflow libraries\n",
+    "import qualified Data.CAS.ContentStore as CS\n",
+    "import Funflow\n",
+    "  ( Flow,\n",
+    "    dockerFlow,\n",
+    "    ioFlow,\n",
+    "    getDirFlow,\n",
+    "    pureFlow,\n",
+    "    putDirFlow,\n",
+    "    runFlow,\n",
+    "  )\n",
+    "import qualified Funflow.Tasks.Docker as DE\n",
+    "\n",
+    "-- Other libraries\n",
+    "import Path (toFilePath, Abs, Dir, Path, File, absdir, parseAbsDir, relfile, reldir, (</>))\n",
+    "import System.Directory (getCurrentDirectory)\n",
+    "import System.Process (runCommand, ProcessHandle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to in Funflow version 1.x, inputs to Docker tasks are mounted in from the content store. This means that we need to copy our example c files to the content store before we can compile them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "-- | Helper for getting the absolute path to the src directory\n",
+    "srcDir :: () -> IO (Path Abs Dir)\n",
+    "srcDir _ = do\n",
+    "  cwd <- getCurrentDirectory\n",
+    "  cwdAbs <- parseAbsDir cwd\n",
+    "  return $ cwdAbs </> [reldir|./src|]\n",
+    "\n",
+    "-- | A `Flow` which copies the c sources to the content store\n",
+    "copyExampleToStore :: Flow () CS.Item\n",
+    "copyExampleToStore = proc _ -> do\n",
+    "  exampleDir <- ioFlow srcDir -< ()\n",
+    "  putDirFlow -< exampleDir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can define a task which compiles the example C files using `gcc`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config :: DE.DockerTaskConfig\n",
+    "config =\n",
+    "  DE.DockerTaskConfig\n",
+    "    { DE.image = \"gcc:9.3.0\",\n",
+    "      DE.command = \"gcc\",\n",
+    "      DE.args = [ \"/example/double.c\", \"/example/square.c\", \"/example/main.c\"]\n",
+    "    }\n",
+    "\n",
+    "-- | Compile our C program and get the path to the output executable\n",
+    "compile :: Flow CS.Item CS.Item\n",
+    "compile = proc exampleItem -> do\n",
+    "  -- Define a volume for the example directory\n",
+    "  let exampleVolume = DE.VolumeBinding {DE.item = exampleItem, DE.mount = [absdir|/example/|]}\n",
+    "  dockerFlow config -< DE.DockerTaskInput {DE.inputBindings = [exampleVolume], DE.argsVals = mempty}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And finally, we can construct our full Flow graph and execute it!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow :: Flow Integer ProcessHandle\n",
+    "flow = proc input -> do\n",
+    "  -- 1. Add the example to the content store\n",
+    "  example <- copyExampleToStore -< ()\n",
+    "  \n",
+    "  -- 2. Compile the C sources and get the path to the new executable\n",
+    "  output <- compile -< example\n",
+    "  outputDir <- getDirFlow -< output\n",
+    "  exe <- pureFlow (\\x -> toFilePath (x </> [relfile|a.out|])) -< outputDir\n",
+    "  \n",
+    "  -- 3. Call the executable\n",
+    "  command <- pureFlow (\\(c, n) -> c <> \" \" <> show n) -< (exe, input)\n",
+    "  ioFlow runCommand -< command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Found docker images, pulling...\n",
+       "Pulling docker image: gcc:9.3.0\n",
+       "15"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Our C program defined in `src/main.c` defines a function f(x) = 2*x + x^2\n",
+    "-- For input 3 this should output 15.\n",
+    "runFlow flow 3 :: IO ProcessHandle"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Haskell - haskell",
+   "language": "haskell",
+   "name": "ihaskell_haskell"
+  },
+  "language_info": {
+   "codemirror_mode": "Haskell",
+   "file_extension": ".hs",
+   "mimetype": "text/x-haskell",
+   "name": "haskell",
+   "pygments_lexer": "Haskell",
+   "version": "8.8.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/funflow-tutorial/notebooks/CCompilation/src/double.c
+++ b/funflow-tutorial/notebooks/CCompilation/src/double.c
@@ -1,0 +1,1 @@
+ int times2(int n) { return 2*n; }

--- a/funflow-tutorial/notebooks/CCompilation/src/main.c
+++ b/funflow-tutorial/notebooks/CCompilation/src/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <stdlib.h>
+int times2(int n);
+int square(int n);
+int main(int argc, char **argv) {
+  int n = atoi(argv[1]);
+  int r = times2(n) + square(n);
+  printf("%d\n", r);
+}

--- a/funflow-tutorial/notebooks/CCompilation/src/square.c
+++ b/funflow-tutorial/notebooks/CCompilation/src/square.c
@@ -1,0 +1,1 @@
+int square(int n) { return n*n; }

--- a/nix/pkgs/jupyter.nix
+++ b/nix/pkgs/jupyter.nix
@@ -13,6 +13,7 @@ tutorialHaskellDependencies = p: with p; [
     containers
     JuicyPixels
     ihaskell-juicypixels
+    process
 ];
 
 iHaskell = jupyterWith.kernels.iHaskellWith {


### PR DESCRIPTION
This PR adds an additional tutorial notebook which recreates the [C compilation example](https://github.com/tweag/funflow/tree/7d8f088f2087423a9314d75c4d0d0c46806dde1e/funflow-examples/compile-and-run-c-files) from funflow 1. 