### PR TITLE
Notes about Docker availability

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,5 +1,18 @@
 # Development
 
+<!-- toc -->
+
+- [Requirements](#requirements)
+- [Development environment](#development-environment)
+  * [VS Code](#vs-code)
+  * [Establish Docker](#establish-docker)
+- [Build with `stack`](#build-with-stack)
+- [CI](#ci)
+  * [Updating the Nix build](#updating-the-nix-build)
+  * [Build locally](#build-locally)
+
+<!-- tocstop -->
+
 ## Requirements
 
 - [Nix](https://nixos.org/nix/)
@@ -32,6 +45,9 @@ Requirements:
   - select the `shell-dev.nix` file
 - [Haskell](https://marketplace.visualstudio.com/items?itemName=haskell.haskell)
   - HLS is provided by the development Nix shell
+
+### Establish Docker
+For tasks like running tests and executing some of the [tutorials](../funflow-tutorial), Docker should be up and running on your machine. Check out the official Docker website for more about [installation](https://docs.docker.com/engine/install/), and perhaps about the [Docker daemon](https://docs.docker.com/config/daemon/).
 
 ## Build with `stack`
 

--- a/funflow-tutorial/README.md
+++ b/funflow-tutorial/README.md
@@ -18,3 +18,7 @@ $ jupyter lab
 The tutorials are written in IPython notebook files in the [notebooks/](./notebooks) directory. Any
 IHaskell notebook stored there will be included with the `funflow` documentation. Tutorials
 with additional supporting files should be placed in a subdirectory, e.g. `notebooks/WordCount/WordCount.ipynb`. 
+
+## Establish Docker
+
+Some tutorials require that Docker is up and running on your machine. Check out the official Docker website for more about [installation](https://docs.docker.com/engine/install/), and perhaps about the [Docker daemon](https://docs.docker.com/config/daemon/).


### PR DESCRIPTION
I wound up solving a few local things by making Docker available, using info from error messages and the `docker-client` folder notes. I thought adding a couple notes about Docker in the development and tutorial README's may help future users with similar things.