### PR TITLE
Improve tests

### DIFF
--- a/funflow/package.yaml
+++ b/funflow/package.yaml
@@ -64,3 +64,4 @@ tests:
       - QuickCheck
       - tasty
       - tasty-hunit
+      - tasty-quickcheck

--- a/funflow/test/unit/TInstances.hs
+++ b/funflow/test/unit/TInstances.hs
@@ -6,11 +6,12 @@ import Data.Maybe (fromJust)
 import qualified Data.Text as Text
 import Path (Abs, Dir, Path, parseAbsDir)
 import Test.QuickCheck
+import TUtils (commonFolderChars)
 
 instance Arbitrary (Path Abs Dir) where
-    arbitrary = let pickChar = elements (['a'..'z'] ++ ['A'..'Z'] ++ ['-', '_'] ++ ['0'..'9'])
-                    chars    = choose (1,5) >>= (\k -> vectorOf k pickChar)
-                    genDir   =  ('/':) <$> chars
+    arbitrary = let makeName k = vectorOf k (elements commonFolderChars)
+                    chars      = choose (1,10) >>= makeName
+                    genDir     =  ('/':) <$> chars
                 in fromJust . parseAbsDir <$> genDir
 
 instance Arbitrary Text.Text where

--- a/funflow/test/unit/TUtils.hs
+++ b/funflow/test/unit/TUtils.hs
@@ -1,0 +1,14 @@
+module TUtils where
+
+import Test.QuickCheck
+import Path (Abs, Dir, Path,Rel,  mkRelDir, (</>))
+
+commonFolderChars :: [Char]
+commonFolderChars = ['a'..'z'] ++ ['A'..'Z'] ++ ['-', '_'] ++ ['0'..'9']
+
+randomRel1 :: Gen String
+randomRel1 = listOf1 (elements commonFolderChars)
+
+{-randomAbs1 :: Path Abs Dir -> Gen (Path Abs Dir)
+randomAbs1 p = (p </>) <$> randomRel1
+-}

--- a/funflow/test/unit/TUtils.hs
+++ b/funflow/test/unit/TUtils.hs
@@ -1,14 +1,9 @@
 module TUtils where
 
 import Test.QuickCheck
-import Path (Abs, Dir, Path,Rel,  mkRelDir, (</>))
 
 commonFolderChars :: [Char]
 commonFolderChars = ['a'..'z'] ++ ['A'..'Z'] ++ ['-', '_'] ++ ['0'..'9']
 
 randomRel1 :: Gen String
 randomRel1 = listOf1 (elements commonFolderChars)
-
-{-randomAbs1 :: Path Abs Dir -> Gen (Path Abs Dir)
-randomAbs1 p = (p </>) <$> randomRel1
--}

--- a/funflow/test/unit/Unit.hs
+++ b/funflow/test/unit/Unit.hs
@@ -15,7 +15,7 @@ import Funflow (Flow, ioFlow, pureFlow, putDirFlow, runFlow)
 import qualified Funflow.Tasks.Docker as DT
 import TInstances()
 
-
+{-
 flow4Item :: Flow () CS.Item
 flow4Item = proc () -> do
   -- Note: the relative path is specific to running the test with Nix with `$(nix-build nix -A funflow.components.tests)/bin/test-funflow`
@@ -52,10 +52,78 @@ prop_DockerTaskInputMonoidAssociativity = QCM.monadicIO $ do
     y <- buildDockerTaskInput
     z <- buildDockerTaskInput
     return ((x <> y) <> z == x <> (y <> z))
+-}
+
+import qualified Data.CAS.ContentHashable as CH
+import Path (Abs, Dir, Path, parseAbsDir)
+import Test.Tasty
+import Test.Tasty.QuickCheck (testProperties)
+import qualified Data.CAS.RemoteCache as RC
+import System.Directory (getCurrentDirectory)
+import Path ((</>))
+
+myNoOp :: Path Abs Dir -> CH.DirectoryContent -> IO ()
+myNoOp _ _ = return ()
+
+myNoErr :: CH.ContentHash -> IO ()
+myNoErr _ = error "uh-oh!"
+
+buildStore :: IO CS.ContentStore
+buildStore = do
+    --cwd <- getCurrentDirectory >>= parseAbsDir
+    cwd <- parseAbsDir "/home/vr/sandbox"
+    CS.open ( cwd </> [reldir|./tmp/store|] )
+
+makeItem :: CS.ContentStore -> Path Abs Dir -> IO CS.Item
+makeItem store p = CS.putInStore store RC.NoCache myNoErr myNoOp (CH.DirectoryContent p)
+
+buildDockerTaskInput :: IO CS.ContentStore -> QCM.PropertyM IO DT.DockerTaskInput
+buildDockerTaskInput getStore = do
+    store      <- QCM.run getStore
+    argsVals   <- QCM.pick arbitrary
+    mountPaths <- QCM.pick (listOf arbitrary)
+    dummyPath  <- QCM.pick arbitrary
+    item       <- QCM.run (makeItem store dummyPath)
+    return DT.DockerTaskInput{ 
+        DT.inputBindings = [DT.VolumeBinding{ DT.item = item, DT.mount = p } | p <- mountPaths] , 
+        DT.argsVals = argsVals
+    }
+
+checkOneInput :: (DT.DockerTaskInput -> Bool) -> IO CS.ContentStore -> Property
+checkOneInput testPred getStore = QCM.monadicIO $ testPred <$> buildDockerTaskInput getStore
+
+prop_DockerTaskInputMonoidLeftIdentity :: IO CS.ContentStore -> Property
+prop_DockerTaskInputMonoidLeftIdentity = checkOneInput (\dti -> mempty <> dti == dti)
+
+prop_DockerTaskInputMonoidRightIdentity :: IO CS.ContentStore -> Property
+prop_DockerTaskInputMonoidRightIdentity = checkOneInput (\dti -> dti == dti <> mempty)
+
+prop_DockerTaskInputMonoidAssociativity :: IO CS.ContentStore -> Property
+prop_DockerTaskInputMonoidAssociativity getStore = QCM.monadicIO $ do
+    x <- buildDockerTaskInput getStore
+    y <- buildDockerTaskInput getStore
+    z <- buildDockerTaskInput getStore
+    return ((x <> y) <> z == x <> (y <> z))
+
+{-monoidDockerTaskInputTests :: IO CS.ContentStore -> TestTree
+monoidDockerTaskInputTests getStore = 
+    testGroup "Monoid DockerInputTask tests" [
+        do 
+    ]
+-}
+
+monoidDockerTaskInputTests :: IO CS.ContentStore -> TestTree
+monoidDockerTaskInputTests getStore = 
+    testProperties "Monoid DockerInputTask tests" [(n, p getStore) | (n, p) <- tests]
+    where tests = [ ("left identity", prop_DockerTaskInputMonoidLeftIdentity), 
+                    ("right identity", prop_DockerTaskInputMonoidRightIdentity), 
+                    ("associativity", prop_DockerTaskInputMonoidAssociativity)
+                  ]
 
 main :: IO ()
-main = do
-    quickCheck prop_DockerTaskInputMonoidLeftIdentity
+main = defaultMain $ testGroup "Units" [withResource buildStore CS.close monoidDockerTaskInputTests]
+       --do
+    {-quickCheck prop_DockerTaskInputMonoidLeftIdentity
     quickCheck prop_DockerTaskInputMonoidRightIdentity
-    quickCheck prop_DockerTaskInputMonoidAssociativity
-    putStrLn "done!"
+    quickCheck prop_DockerTaskInputMonoidAssociativity-}
+    --putStrLn "done!"

--- a/funflow/test/unit/Unit.hs
+++ b/funflow/test/unit/Unit.hs
@@ -6,63 +6,20 @@
 
 -- Funflow unit tests
 
-import Path (parseAbsDir, reldir, (</>))
+import Data.Maybe (fromMaybe)
+import Path (Abs, Dir, Path, parseAbsDir, toFilePath)
+import Path.IO (createDirIfMissing)
 import System.Directory (getCurrentDirectory)
 import Test.QuickCheck
-import qualified Test.QuickCheck.Monadic as QCM
-
-import qualified Data.CAS.ContentStore as CS
-import Funflow (Flow, ioFlow, pureFlow, putDirFlow, runFlow)
-import qualified Funflow.Tasks.Docker as DT
-import TInstances()
-
-{-
-flow4Item :: Flow () CS.Item
-flow4Item = proc () -> do
-  -- Note: the relative path is specific to running the test with Nix with `$(nix-build nix -A funflow.components.tests)/bin/test-funflow`
-  --       which is the case in the CI
-  testDir <- ioFlow (\() -> return . flip (</>) [reldir|./funflow/test/flows/assets/storeFlowTest/|] =<< parseAbsDir =<< getCurrentDirectory) -< ()
-  item <- putDirFlow -< testDir    -- get the CS.Item by piping through the temp folder
-  pureFlow $ id -< item
-
-getTempDirItem :: IO CS.Item
-getTempDirItem = runFlow flow4Item ()
-
-buildDockerTaskInput :: QCM.PropertyM IO DT.DockerTaskInput
-buildDockerTaskInput = do
-    argsVals <- QCM.pick arbitrary
-    mountPaths <- QCM.pick (listOf arbitrary)
-    item <- QCM.run getTempDirItem
-    return DT.DockerTaskInput{ 
-        DT.inputBindings = [DT.VolumeBinding{ DT.item = item, DT.mount = p } | p <- mountPaths] , 
-        DT.argsVals = argsVals
-    }
-
-checkOneInput :: (DT.DockerTaskInput -> Bool) -> Property
-checkOneInput testPred = QCM.monadicIO $ testPred <$> buildDockerTaskInput
-
-prop_DockerTaskInputMonoidLeftIdentity :: Property
-prop_DockerTaskInputMonoidLeftIdentity = checkOneInput (\dti -> mempty <> dti == dti)
-
-prop_DockerTaskInputMonoidRightIdentity :: Property
-prop_DockerTaskInputMonoidRightIdentity = checkOneInput (\dti -> dti == dti <> mempty)
-
-prop_DockerTaskInputMonoidAssociativity :: Property
-prop_DockerTaskInputMonoidAssociativity = QCM.monadicIO $ do
-    x <- buildDockerTaskInput
-    y <- buildDockerTaskInput
-    z <- buildDockerTaskInput
-    return ((x <> y) <> z == x <> (y <> z))
--}
-
-import qualified Data.CAS.ContentHashable as CH
-import Path (Abs, Dir, Path, mkRelDir, parseAbsDir, toFilePath, (</>))
-import Path.IO (createDirIfMissing)
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperties)
+import qualified Test.QuickCheck.Monadic as QCM
+
+import qualified Data.CAS.ContentHashable as CH
+import qualified Data.CAS.ContentStore as CS
 import qualified Data.CAS.RemoteCache as RC
-import System.Directory (getCurrentDirectory, removeDirectoryRecursive)
-import TUtils (randomRel1)
+import qualified Funflow.Tasks.Docker as DT
+import TInstances()
 
 myNoOp :: Path Abs Dir -> CH.DirectoryContent -> IO ()
 myNoOp _ _ = return ()
@@ -70,22 +27,19 @@ myNoOp _ _ = return ()
 myNoErr :: CH.ContentHash -> IO ()
 myNoErr _ = error "uh-oh!"
 
-type Fixture = IO (Path Abs Dir, CS.ContentStore)
+type Fixture = IO CS.Item
 
 fixture :: Fixture
-fixture = tmp >>= (\p -> (\s -> (p,s)) <$> CS.open p)
+fixture = tmp >>= (\p -> CS.withStore p (\s -> mkIt s p))
     where path = getCurrentDirectory >>= parseAbsDir >>= (\p -> parseAbsDir $ toFilePath p ++ ".tmp/store")
           tmp = path >>= createDirIfMissing True >>= (\_ -> path)
-
-makeItem :: CS.ContentStore -> Path Abs Dir -> IO CS.Item
-makeItem store p = CS.putInStore store RC.NoCache myNoErr myNoOp (CH.DirectoryContent p)
+          mkIt s p = CS.putInStore s RC.NoCache myNoErr myNoOp (CH.DirectoryContent p)
 
 buildDockerTaskInput :: Fixture -> QCM.PropertyM IO DT.DockerTaskInput
 buildDockerTaskInput setup = do
-    (tmp, store) <- QCM.run setup
+    item         <- QCM.run setup
     argsVals     <- QCM.pick arbitrary
     mountPaths   <- QCM.pick (listOf arbitrary)
-    item         <- QCM.run (makeItem store tmp)
     return DT.DockerTaskInput{ 
         DT.inputBindings = [DT.VolumeBinding{ DT.item = item, DT.mount = p } | p <- mountPaths] , 
         DT.argsVals = argsVals
@@ -109,15 +63,14 @@ prop_DockerTaskInputMonoidAssociativity setup = QCM.monadicIO $ do
 
 monoidDockerTaskInputTests :: Fixture -> TestTree
 monoidDockerTaskInputTests setup = 
-    let makeProp x prop = withMaxSuccess x (prop setup)
-        specs = [ ("left identity", prop_DockerTaskInputMonoidLeftIdentity, 5), 
-                  ("right identity", prop_DockerTaskInputMonoidRightIdentity, 5), 
-                  ("associativity", prop_DockerTaskInputMonoidAssociativity, 2)
+    let makeProp x prop = withMaxSuccess (fromMaybe 100 x) (prop setup)
+        specs = [ ("left identity", prop_DockerTaskInputMonoidLeftIdentity, Nothing), 
+                  ("right identity", prop_DockerTaskInputMonoidRightIdentity, Nothing), 
+                  ("associativity", prop_DockerTaskInputMonoidAssociativity, Nothing)
                 ]
     in testProperties "Monoid DockerInputTask tests" [(n, makeProp x p) | (n, p, x) <- specs]
 
 main :: IO ()
---main = let cleanup (tmpdir, store) = CS.close store >> removeDirectoryRecursive (toFilePath tmpdir)
-main = let cleanup (_, store) = CS.close store
-           testCtx            = withResource fixture cleanup
+main = let cleanup _ = return ()
+           testCtx   = withResource fixture cleanup
        in defaultMain $ testGroup "Units" [testCtx monoidDockerTaskInputTests]


### PR DESCRIPTION
Speedup to no longer need low limit on successes, mainly by sharing a `ContentStore.Item` value across all property tests.