### PR TITLE
Update documentation

### DIFF
--- a/funflow/src/Funflow/Run.hs
+++ b/funflow/src/Funflow/Run.hs
@@ -64,8 +64,8 @@ import Docker.API.Client
   )
 import Funflow.Config (ConfigKeysBySource (..), Configurable (..), ExternalConfig (..), missing, readEnvs, readYamlFileConfig)
 import Funflow.Flow (RequiredCore, RequiredStrands)
-import Funflow.Run.Orphans ()
 import Funflow.Flow.Orphans ()
+import Funflow.Run.Orphans ()
 import Funflow.Tasks.Docker
   ( Arg (Arg, Placeholder),
     DockerTask (DockerTask),
@@ -98,8 +98,12 @@ data RunFlowConfig = RunFlowConfig
   }
 
 -- | Run a flow, parsing any required `Configurable` values from their respective sources.
--- Note that this method does NOT provide an implementation of parsing ConfigFromCLI
--- values at the moment.
+-- This flow executor includes interpreters for the following tasks:
+--
+--  * `SimpleTask`
+--  * `StoreTask`
+--  * `DockerTask` - The container is run with working directory '/workdir'. Files written to this directory
+--    are included in the tasks's `CS.Item` output.
 runFlowWithConfig ::
   -- | The configuration of the flow
   RunFlowConfig ->

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -43,6 +43,10 @@
       docker-client-tests = project.docker-client.components.tests.primary.overrideAttrs (old:
         { buildInputs = old.buildInputs ++ [ super.docker ]; }
       );
+      # Also include kernmantle for references in the docs
+      kernmantle = project.kernmantle.components.library;
+      kernmantle-batteries = project.kernmantle-batteries.components.library;
+      kernmantle-caching = project.kernmantle-caching.components.library;
     }
   )
 
@@ -94,6 +98,9 @@
             cas-hashable-s3
             external-executor
             docker-client
+            kernmantle
+            kernmantle-batteries
+            kernmantle-caching
           ];
         in
           self.haddock-combine { hspkgs = doc-libs; };


### PR DESCRIPTION
Updates the docstring for `runFlowWithConfig` to indicate which working directory its docker interpreter uses and adds `kernmantle` to the API docs.