### PR TITLE
add message about Docker/Internet; close #106

### DIFF
--- a/funflow/src/Funflow/Run.hs
+++ b/funflow/src/Funflow/Run.hs
@@ -176,7 +176,8 @@ runFlowWithConfig config flow input =
                     putStrLn $ "Pulling docker image: " ++ T.unpack image
                     pullResult <- runExceptT $ pullImage manager image
                     case pullResult of
-                      Left ex ->
+                      Left ex -> do
+                        putStrLn "Error pulling docker image; is Internet connected? Is Docker running?"
                         throw ex
                       Right _ ->
                         -- No error, just continue


### PR DESCRIPTION
Went conservative route and just added message for some context rather than different error type or applying `ImagePullError` to this case as well.