### PR TITLE
Caching in makefile-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cabal.sandbox.config
 cabal.project.local
 
 .vscode
+.idea/
 
 result*
 

--- a/funflow-examples/makefile-tool/src/Main.hs
+++ b/funflow-examples/makefile-tool/src/Main.hs
@@ -11,7 +11,6 @@ module Main where
 
 import Control.Arrow
 import Control.Exception (SomeException (..))
-import Control.Kernmantle.Caching (caching)
 import Control.Kernmantle.Error (tryE)
 import Control.Monad (guard)
 import qualified Data.ByteString as BS
@@ -25,6 +24,7 @@ import Data.Typeable (Typeable)
 import Funflow
   ( Flow,
     RunFlowConfig (..),
+    caching,
     dockerFlow,
     ioFlow,
     pureFlow,

--- a/funflow-examples/package.yaml
+++ b/funflow-examples/package.yaml
@@ -18,7 +18,6 @@ dependencies:
   - directory
   - funflow
   - kernmantle
-  - kernmantle-caching
   - parsec
   - path
   - path-io

--- a/funflow-examples/package.yaml
+++ b/funflow-examples/package.yaml
@@ -18,6 +18,7 @@ dependencies:
   - directory
   - funflow
   - kernmantle
+  - kernmantle-caching
   - parsec
   - path
   - path-io


### PR DESCRIPTION
Close #110 

@dorranh I ran up against ambiguity in the `core` type and inability to deduce a `ProvidesPosCaching` instance when I tried out `caching'`, so I went with regular `caching`, which seems to work. This compiled and when I execute repeatedly, I get the expected short circuit / early cutoff behavior that I don't with the version on `master`
